### PR TITLE
contain paint

### DIFF
--- a/sauce.css
+++ b/sauce.css
@@ -138,6 +138,7 @@ cite {
 }
 
 .oral {
+  contain: paint;
   margin: 0;
   font-size: 0;
   line-height: 0;


### PR DESCRIPTION
### [`paint`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain)

> Indicates that descendants of the element don't display outside its bounds. If the containing box is offscreen, the browser does not need to paint its contained elements — these must also be offscreen as they are contained completely by that box. And if a descendant overflows the containing element's bounds, then that descendant will be clipped to the containing element's border-box.